### PR TITLE
Remove local config directory and refactor helper.

### DIFF
--- a/process_sarif/sarif_helpers.py
+++ b/process_sarif/sarif_helpers.py
@@ -45,14 +45,26 @@ def replace_misra_rules(files: List[SarifFile], rules_txt_path: str, verbose=Fal
     """
     Load MISRA rules from share/config/misra_rules.txt, and applies them to any Result in a
     SarifFile referencing a MISRA rule.
+
+    The rules text should be in this format:
+
+    rule_id_1\tRule ID 1 description
+    rule_id_2\tRule ID 2 description
+    ...
+    rule_id_n\tRule ID n description
     """
 
     rules = {}
 
     share_dir = get_package_share_directory("process_sarif")
 
+    if not os.path.exists(rules_txt_path):
+        if verbose: print("Rules text path does not exist! Not replacing rules.")
+
+        return files
+
     # Load into rules dict from misra_rules
-    with open(rules_txt_path)) as f:
+    with open(rules_txt_path) as f:
         for line in f.readlines():
             rule_id, text = line.split("\t")
             rules[rule_id] = text

--- a/process_sarif/sarif_helpers.py
+++ b/process_sarif/sarif_helpers.py
@@ -41,7 +41,7 @@ def get_sarif_in_build(whitelist=[], verbose=True, log_path: Optional[str] = Non
 
     return sarif_files
 
-def replace_misra_rules(files: List[SarifFile], verbose=False) -> List[SarifFile]:
+def replace_misra_rules(files: List[SarifFile], rules_txt_path: str, verbose=False) -> List[SarifFile]:
     """
     Load MISRA rules from share/config/misra_rules.txt, and applies them to any Result in a
     SarifFile referencing a MISRA rule.
@@ -52,7 +52,7 @@ def replace_misra_rules(files: List[SarifFile], verbose=False) -> List[SarifFile
     share_dir = get_package_share_directory("process_sarif")
 
     # Load into rules dict from misra_rules
-    with open(os.path.join(share_dir, "config/misra_rules.txt")) as f:
+    with open(rules_txt_path)) as f:
         for line in f.readlines():
             rule_id, text = line.split("\t")
             rules[rule_id] = text

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     packages=[package_name],
     data_files=[
         ('share/' + package_name, ['package.xml']),
-        ('share/' + package_name + "/config", glob('config/*')),
         ('share/' + package_name + "/resources", glob('resources/*'))
     ],
     install_requires=['setuptools'],


### PR DESCRIPTION
Since we've removed the misra_rules.txt configuration file that's no
longer part of this package and setup.py does not need to reference it.

I've also proposed a small refactor to the replace_misra_rules helper to
allow the path to a local rules file to be specified rather than
assuming there is one distributed with the package.