### PR TITLE
Drop unused import.

### DIFF
--- a/process_sarif/sarif_helpers.py
+++ b/process_sarif/sarif_helpers.py
@@ -3,7 +3,6 @@
 import os
 
 from typing import List, Tuple, Optional
-from ament_index_python.packages import get_package_share_directory
 from process_sarif.sarif import SarifFile, Result
 
 


### PR DESCRIPTION
This function is no longer being used and since it is not a declared package.xml dependency it is creating problems when building in an isolated colcon workspace.