### PR TITLE
Add snap

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,51 @@
+name: snap
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # full history for latest tag name
+        fetch-depth: 0
+    - uses: snapcore/action-build@v1
+      id: build-snap
+
+    # Make sure the snap is installable
+    - run: |
+        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+    - run: |
+        process-sarif.sarif-load-test
+    - uses: actions/upload-artifact@v3
+      with:
+        name: process-sarif
+        path: ${{ steps.build-snap.outputs.snap }}
+
+  publish:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: process-sarif
+        path: .
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      if: ${{ env.SNAPCRAFT_STORE_CREDENTIALS != '' }}
+      with:
+        snap: ${{needs.build.outputs.snap-file}}
+        release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ These are files that aren't run directly, but can be imported by your own script
     - Many Cobra files cannot be loaded due to invalid JSON, or non-conformance to the SARIF spec.
 
 ## 4. Snap
-These tools are also available to install from the [Snap Store](https://snapcraft.io/about) as a [snap](https://snapcraft.io/process-sarif).
+These tools are available to install from the [Snap Store](https://snapcraft.io/about) as a [snap](https://snapcraft.io/process-sarif) as a complementary packaging option maintained by Canonical.
+
 ### Install: 
 `snap install process-sarif`
 ### Usage

--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ These are files that aren't run directly, but can be imported by your own script
 - There should be visualizations of these different aggregations.
 - All testing tools should output valid SARIF.
     - Many Cobra files cannot be loaded due to invalid JSON, or non-conformance to the SARIF spec.
+
+## 4. Snap
+These tools are also available to install as a [snap](https://snapcraft.io/about).
+### Install: 
+`snap install process-sarif`
+### Usage
+Navigate to a directory containing the SARIF file(s) you wish to analyze. Run any of the available commands (sarif-load-test, conformance, duplicates, visualize), as `process-sarif.<app_name>` (ie: process-sarif.sarif-load-test)
+

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These are files that aren't run directly, but can be imported by your own script
     - Many Cobra files cannot be loaded due to invalid JSON, or non-conformance to the SARIF spec.
 
 ## 4. Snap
-These tools are also available to install as a [snap](https://snapcraft.io/about).
+These tools are also available to install from the [Snap Store](https://snapcraft.io/about) as a [snap](https://snapcraft.io/process-sarif).
 ### Install: 
 `snap install process-sarif`
 ### Usage

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,57 @@
+name: process-sarif
+version: '0.0.1'
+license: Apache-2.0
+summary: SARIF processing tools by Space ROS
+description: |
+  The process-sarif snap provides tools and scripts to assist in parsing and aggregating output of static analysis tools in  SARIF (Static Analysis Results Interchange Format) standard format. Its features include parsing a .sarif file, removing duplicated results, and generating visualizations by result level and severity. The project is developed and maintained by Space ROS.
+  * Source: https://github.com/space-ros/process_sarif
+  * Installation: `snap install process-sarif`
+  * Usage: Navigate to a directory containing the SARIF file(s) you wish to analyze. Run any of the available commands (sarif-load-test, conformance, duplicates, visualize), as `process-sarif.<app_name>` (ie: process-sarif.sarif-load-test)
+
+confinement: strict
+base: core22
+grade: stable
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+layout:
+  /usr/share/matplotlib/mpl-data:
+    bind: $SNAP/usr/share/matplotlib/mpl-data
+  /etc/matplotlibrc:
+    bind-file: $SNAP/etc/matplotlibrc
+  /usr/share/tcltk:
+    bind: $SNAP/usr/share/tcltk
+
+parts:
+ process-sarif:
+   plugin: colcon
+   source: https://github.com/space-ros/process_sarif.git
+   source-branch: main
+   stage-packages: 
+   - python3-matplotlib
+   - python3-tk # need to install tkinter as a dependency of matplotlib
+   - ros-humble-ros2run
+
+apps:
+ sarif-load-test:
+   command: opt/ros/humble/bin/ros2 run process_sarif sarif_load_test
+   plugs: [home]
+   extensions: [ros2-humble]
+ conformance:
+   command: opt/ros/humble/bin/ros2 run process_sarif conformance
+   plugs: [home]
+   extensions: [ros2-humble]
+ duplicates:
+   command: opt/ros/humble/bin/ros2 run process_sarif duplicates
+   plugs: [home]
+   extensions: [ros2-humble] 
+ visualize:
+   command: opt/ros/humble/bin/ros2 run process_sarif visualize
+   plugs: 
+    - home
+    - x11
+   extensions: [ros2-humble] 
+   environment:
+    LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack"
+    # need to specify the python path to find tkinter dependency
+    PYTHONPATH: "$PYTHONPATH:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.10:$SNAP/usr/lib/python3.10/lib-dynload"


### PR DESCRIPTION
Hello Space ROS team,

I would like to contribute [a snap](https://snapcraft.io/about) for this process_sarif project. If you’re not familiar with them, snaps are packages of an app and its dependencies for desktop, cloud and IoT. They are easy to install, secure, cross‐platform and self-contained.

A number of open source code security tools are already available to install as snaps (see [ikos](https://snapcraft.io/ikos), [cppcheck](https://snapcraft.io/cppcheckgui), [flawfinder](https://snapcraft.io/flawfinder)), but none other for SARIF file processing, which I think can make this an interesting contribution.

The snap is now [available on the snap store](https://snapcraft.io/process-sarif) (unlisted, so it cannot be found via the search engine). Give it a shot with `snap install process-sarif`. Currently, each of the 4 tools described in the main repo (sarif_load_test, conformance, duplicates, visualize) can be run as `process-sarif.<tool_name>` (ie: `process-sarif.sarif-load-test`) once the snap is installed. Other tools can easily be added to this snap as well. 

Please go ahead, give it a try and let me know what you think. If you would be interested in merging this and maintaining the snap, I can transfer the ownership to you on the snap store.

Please let me know if I can help answer any questions.

Cheers,
Florencia.